### PR TITLE
add orb setting instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ bundle install --path=vendor/bundle
 
 ![CircleCI](img/circleci.png)
 
+For third party orbs, set 'Allow Uncertified Orbs' option in organization security settings.
+See https://circleci.com/docs/2.0/orbs-faq/#using-3rd-party-orbs.
+
 ### 3. Register a GitHub cache url (optional)
 Register a GitHub cache url (e.g. `https://camo.githubusercontent.com/xxxxxxxxxx`) after paste a badge to GitHub
 


### PR DESCRIPTION
Security settings are required to use third party orbs in CircleCI.
I add the instruction of this settings to README.md.

<img width="957" alt="169ae5f2dab21682ff45b959" src="https://user-images.githubusercontent.com/1789266/54875817-ed752500-4e48-11e9-8afb-97c75a44a6a5.png">