### PR TITLE
Fixed `Capybara::ElementNotFound`

### DIFF
--- a/lib/twilog.rb
+++ b/lib/twilog.rb
@@ -24,7 +24,7 @@ class Twilog
 
   def update
     session.visit(twilog_url)
-    session.find(:xpath, "//section[@id='side-update']//input[@type='submit' and @class='ub']").click
+    session.find(:xpath, "//form[@action='/#{@twitter_id}/fetch']//input[@type='submit']").click
 
     if session.current_url != twilog_url && session.current_url != "#{twilog_url}?status=fetchSuccess"
       raise "current_url is unexpected: #{session.current_url}"


### PR DESCRIPTION
```
Capybara::ElementNotFound: Unable to find xpath "//section[@id='side-update']//input[@type='submit' and @class='ub']" (Capybara::ElementNotFound)
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:312:in `block in synced_resolve'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/base.rb:84:in `synchronize'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:301:in `synced_resolve'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/node/finders.rb:60:in `find'
/home/circleci/app/vendor/bundle/ruby/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:774:in `find'
/home/circleci/app/lib/twilog.rb:27:in `update'
```

https://app.circleci.com/pipelines/github/sue445/tweet_pixels/7670/workflows/78a12ee9-ed55-4015-901e-f75f2142aaf4/jobs/10228